### PR TITLE
[SYCL] Update to SYCL 1.2.1

### DIFF
--- a/tensorflow/workspace.bzl
+++ b/tensorflow/workspace.bzl
@@ -196,10 +196,10 @@ def tf_workspace(path_prefix="", tf_repo_name=""):
       name = "eigen_archive",
       urls = [
           #"http://mirror.bazel.build/bitbucket.org/eigen/eigen/get/c484b7bc76d5.tar.gz",
-          "https://bitbucket.org/mehdi_goli/opencl/get/0701f78ee2de.tar.gz",
+          "https://bitbucket.org/mehdi_goli/opencl/get/8e8bc4c3efee.tar.gz",
       ],
       #sha256 = "ca7beac153d4059c02c8fc59816c82d54ea47fe58365e8aded4082ded0b820c4",
-      strip_prefix = "mehdi_goli-opencl-0701f78ee2de",
+      strip_prefix = "mehdi_goli-opencl-8e8bc4c3efee",
       build_file = str(Label("//third_party:eigen.BUILD")),
   )
 

--- a/third_party/sycl/crosstool/computecpp.tpl
+++ b/third_party/sycl/crosstool/computecpp.tpl
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
+
 import os
 import sys
 import tempfile
-from subprocess import call, Popen, PIPE
+from subprocess import call, Popen, PIPE, check_output
 
 CPU_CXX_COMPILER = ('%{host_cxx_compiler}')
 CPU_C_COMPILER = ('%{host_c_compiler}')
@@ -130,6 +132,14 @@ def get_host_compiler_flags(compiler_flags, bc_out):
   return host_compiler_flags
 
 def main():
+  outputList = check_output([COMPUTECPP_DRIVER, '--version']).split(" ")
+  cpp_version = outputList[outputList.index('Device') - 1];
+  cppVersionList = cpp_version.split(".")
+  if int(cppVersionList[0]) == 0 and int(cppVersionList[1]) < 5:
+    print("Error: ComputeCpp {} is not compatible with the current version of Tensorflow, "
+          "please update to the latest version of ComputeCpp".format(cpp_version), file=sys.stderr)
+    return 1
+
   compiler_flags = clean_passed_in_flags()
 
   output_file_index = compiler_flags.index('-o') + 1


### PR DESCRIPTION
14 tests failed out of 284 with AMD GPU. I'm running them again without these changes to see if we lost any tests but it seems reasonable.
The version couldn't be checked with CL_SYCL_LANGUAGE_VERSION after all. So I have something similar to what Luke is doing on dev/amd_gpu to check version of the compiler instead.