### PR TITLE
[SYCL] Compile with -fPIC instead of -fPIE

### DIFF
--- a/third_party/sycl/crosstool/CROSSTOOL.tpl
+++ b/third_party/sycl/crosstool/CROSSTOOL.tpl
@@ -82,7 +82,7 @@ toolchain {
 
   compiler_flag: "-ffunction-sections"
   compiler_flag: "-fdata-sections"
-  compiler_flag: "-fPIE"
+  compiler_flag: "-fPIC"
   compiler_flag: "-fno-omit-frame-pointer"
   compiler_flag: "-Wall"
 
@@ -184,7 +184,7 @@ toolchain {
 
   compiler_flag: "-ffunction-sections"
   compiler_flag: "-fdata-sections"
-  compiler_flag: "-fPIE"
+  compiler_flag: "-fPIC"
   compiler_flag: "-fno-omit-frame-pointer"
   compiler_flag: "-Wall"
 


### PR DESCRIPTION
Fixes one of the issues mentioned here: https://github.com/lukeiwanski/tensorflow/issues/246